### PR TITLE
Fixed button execution when reopening menu.

### DIFF
--- a/warmenu.lua
+++ b/warmenu.lua
@@ -268,6 +268,7 @@ function WarMenu.CloseMenu()
             PlaySoundFrontend(-1, "QUIT", "HUD_FRONTEND_DEFAULT_SOUNDSET", true)
             optionCount = 0
             currentMenu = nil
+            currentKey = nil
         else
             menus[currentMenu].aboutToBeClosed = true
             debugPrint(tostring(currentMenu)..' menu about to be closed')


### PR DESCRIPTION
When a menu would reopen, the first button to be shown would be clicked as the currentKey wasn't reset in closeMenu.