### PR TITLE
Added ability to add Sprites to button text.

### DIFF
--- a/warmenu.lua
+++ b/warmenu.lua
@@ -131,12 +131,7 @@ local function drawSubTitle()
     end
 end
 
-local function drawButton(text, textureDictMain, textureNameMain, subText, textureDictSub, textureNameSub)
-    textureDictMain = textureDictMain or "commonmenu"
-    textureNameMain = textureNameMain or "shop_tick_icon"
-    textureDictSub = textureDictSub or "commonmenu"
-    textureNameSub = textureNameSub or "shop_tick_icon"
-
+local function drawButton(text, subText)
     local x = menus[currentMenu].x + menuWidth / 2
     local multiplier = nil
 
@@ -166,29 +161,29 @@ local function drawButton(text, textureDictMain, textureNameMain, subText, textu
 
         drawRect(x, y, menuWidth, buttonHeight, backgroundColor)
 
-        if (text == "*_SPRITE_*") then
-            while (not HasStreamedTextureDictLoaded(textureDictMain)) do
-                RequestStreamedTextureDict(textureDictMain, true)
+        if (type(text) == "table") then
+            while (not HasStreamedTextureDictLoaded(text["textureDict"])) do
+                RequestStreamedTextureDict(text["textureDict"], true)
 
                 Citizen.Wait(0)
             end
 
-            DrawSprite(textureDictMain, textureNameMain, menus[currentMenu].x + (buttonTextXOffset + 0.01), y - (buttonHeight / 2) + (buttonTextYOffset + 0.015), 0.025, 0.04, 0.0, textColor.r, textColor.g, textColor.b, textColor.a)
+            DrawSprite(text["textureDict"], text["textureName"], menus[currentMenu].x + (buttonTextXOffset + 0.01), y - (buttonHeight / 2) + (buttonTextYOffset + 0.015), 0.025, 0.04, 0.0, textColor.r, textColor.g, textColor.b, textColor.a)
         else
-            drawText(text, menus[currentMenu].x + buttonTextXOffset, y - (buttonHeight / 2) + buttonTextYOffset, buttonFont, textColor, buttonScale, false, shadow)
+            drawText(tostring(text), menus[currentMenu].x + buttonTextXOffset, y - (buttonHeight / 2) + buttonTextYOffset, buttonFont, textColor, buttonScale, false, shadow)
         end
 
         if subText then
-            if (subText == "*_SPRITE_*") then
-                while (not HasStreamedTextureDictLoaded(textureDictSub)) do
-                    RequestStreamedTextureDict(textureDictSub, true)
+            if (type(subText) == "table") then
+                while (not HasStreamedTextureDictLoaded(subText["textureDict"])) do
+                    RequestStreamedTextureDict(subText["textureDict"], true)
 
                     Citizen.Wait(0)
                 end
 
-                DrawSprite(textureDictSub, textureNameSub, menus[currentMenu].x + (menuWidth - 0.03) + (buttonTextXOffset + 0.01), y - (buttonHeight / 2) + (buttonTextXOffset + 0.014), 0.025, 0.04, 0.0, subTextColor.r, subTextColor.g, subTextColor.b, subTextColor.a)
+                DrawSprite(subText["textureDict"], subText["textureName"], menus[currentMenu].x + (menuWidth - 0.025) + (buttonTextXOffset + 0.01), y - (buttonHeight / 2) + (buttonTextXOffset + 0.014), 0.025, 0.04, 0.0, subTextColor.r, subTextColor.g, subTextColor.b, subTextColor.a)
             else
-                drawText(subText, menus[currentMenu].x + buttonTextXOffset, y - buttonHeight / 2 + buttonTextYOffset, buttonFont, subTextColor, buttonScale, false, shadow, true)
+                drawText(tostring(subText), menus[currentMenu].x + buttonTextXOffset, y - buttonHeight / 2 + buttonTextYOffset, buttonFont, subTextColor, buttonScale, false, shadow, true)
             end
         end
     end
@@ -209,8 +204,8 @@ function WarMenu.CreateMenu(id, title)
     menus[id].aboutToBeClosed = false
 
     -- Top left corner
-    menus[id].x = 0.0175
-    menus[id].y = 0.025
+    menus[id].x = 0.35 -- 0.0175
+    menus[id].y = 0.35 -- 0.025
 
     menus[id].currentOption = 1
     menus[id].maxOptionCount = 10
@@ -313,12 +308,7 @@ function WarMenu.CloseMenu()
 end
 
 
-function WarMenu.Button(text, textureDictMain, textureNameMain, subText, textureDictSub, textureNameSub)
-    textureDictMain = textureDictMain or "commonmenu"
-    textureNameMain = textureNameMain or "shop_tick_icon"
-    textureDictSub = textureDictSub or "commonmenu"
-    textureNameSub = textureNameSub or "shop_tick_icon"
-    
+function WarMenu.Button(text, subText) 
     local buttonText = text
     if subText then
         buttonText = '{ '..tostring(buttonText)..', '..tostring(subText)..' }'
@@ -329,7 +319,7 @@ function WarMenu.Button(text, textureDictMain, textureNameMain, subText, texture
 
         local isCurrent = menus[currentMenu].currentOption == optionCount
 
-        drawButton(text, textureDictMain, textureNameMain, subText, textureDictSub, textureNameSub)
+        drawButton(text, subText)
 
         if isCurrent then
             if currentKey == keys.select then
@@ -377,7 +367,7 @@ function WarMenu.CheckBox(text, bool, callback)
         --checked = 'On'
     end
 
-    if WarMenu.Button(text, false, false, "*_SPRITE_*", "commonmenu", currentTexture) then
+    if WarMenu.Button(text, {["textureDict"] = "commonmenu", ["textureName"] = currentTexture}) then
         bool = not bool
         debugPrint(tostring(text)..' checkbox changed to '..tostring(bool))
         callback(bool)

--- a/warmenu.lua
+++ b/warmenu.lua
@@ -173,7 +173,7 @@ local function drawButton(text, textureDictMain, textureNameMain, subText, textu
                 Citizen.Wait(0)
             end
 
-            DrawSprite(textureDictMain, textureNameMain, menus[currentMenu].x + buttonTextXOffset, y - (buttonHeight / 2) + buttonTextYOffset, 0.025, 0.04, 0.0, textColor.r, textColor.g, textColor.b, textColor.a)
+            DrawSprite(textureDictMain, textureNameMain, menus[currentMenu].x + (buttonTextXOffset + 0.01), y - (buttonHeight / 2) + (buttonTextYOffset + 0.015), 0.025, 0.04, 0.0, textColor.r, textColor.g, textColor.b, textColor.a)
         else
             drawText(text, menus[currentMenu].x + buttonTextXOffset, y - (buttonHeight / 2) + buttonTextYOffset, buttonFont, textColor, buttonScale, false, shadow)
         end
@@ -186,7 +186,7 @@ local function drawButton(text, textureDictMain, textureNameMain, subText, textu
                     Citizen.Wait(0)
                 end
 
-                DrawSprite(textureDictSub, textureNameSub, menus[currentMenu].x + (menuWidth - buttonTextXOffset - menus[currentMenu].x), y - buttonHeight / 2 + (menus[currentMenu].y - buttonTextXOffset), 0.04, 0.05, 0.0, textColor.r, textColor.g, textColor.b, textColor.a)
+                DrawSprite(textureDictSub, textureNameSub, menus[currentMenu].x + (menuWidth - 0.03) + (buttonTextXOffset + 0.01), y - (buttonHeight / 2) + (buttonTextXOffset + 0.014), 0.025, 0.04, 0.0, subTextColor.r, subTextColor.g, subTextColor.b, subTextColor.a)
             else
                 drawText(subText, menus[currentMenu].x + buttonTextXOffset, y - buttonHeight / 2 + buttonTextYOffset, buttonFont, subTextColor, buttonScale, false, shadow, true)
             end

--- a/warmenu.lua
+++ b/warmenu.lua
@@ -131,8 +131,12 @@ local function drawSubTitle()
     end
 end
 
+local function drawButton(text, textureDictMain, textureNameMain, subText, textureDictSub, textureNameSub)
+    textureDictMain = textureDictMain or "commonmenu"
+    textureNameMain = textureNameMain or "shop_tick_icon"
+    textureDictSub = textureDictSub or "commonmenu"
+    textureNameSub = textureNameSub or "shop_tick_icon"
 
-local function drawButton(text, subText)
     local x = menus[currentMenu].x + menuWidth / 2
     local multiplier = nil
 
@@ -161,14 +165,34 @@ local function drawButton(text, subText)
         end
 
         drawRect(x, y, menuWidth, buttonHeight, backgroundColor)
-        drawText(text, menus[currentMenu].x + buttonTextXOffset, y - (buttonHeight / 2) + buttonTextYOffset, buttonFont, textColor, buttonScale, false, shadow)
+
+        if (text == "*_SPRITE_*") then
+            while (not HasStreamedTextureDictLoaded(textureDictMain)) do
+                RequestStreamedTextureDict(textureDictMain, true)
+
+                Citizen.Wait(0)
+            end
+
+            DrawSprite(textureDictMain, textureNameMain, menus[currentMenu].x + buttonTextXOffset, y - (buttonHeight / 2) + buttonTextYOffset, 0.025, 0.04, 0.0, textColor.r, textColor.g, textColor.b, textColor.a)
+        else
+            drawText(text, menus[currentMenu].x + buttonTextXOffset, y - (buttonHeight / 2) + buttonTextYOffset, buttonFont, textColor, buttonScale, false, shadow)
+        end
 
         if subText then
-            drawText(subText, menus[currentMenu].x + buttonTextXOffset, y - buttonHeight / 2 + buttonTextYOffset, buttonFont, subTextColor, buttonScale, false, shadow, true)
+            if (subText == "*_SPRITE_*") then
+                while (not HasStreamedTextureDictLoaded(textureDictSub)) do
+                    RequestStreamedTextureDict(textureDictSub, true)
+
+                    Citizen.Wait(0)
+                end
+
+                DrawSprite(textureDictSub, textureNameSub, menus[currentMenu].x + (menuWidth - buttonTextXOffset - menus[currentMenu].x), y - buttonHeight / 2 + (menus[currentMenu].y - buttonTextXOffset), 0.04, 0.05, 0.0, textColor.r, textColor.g, textColor.b, textColor.a)
+            else
+                drawText(subText, menus[currentMenu].x + buttonTextXOffset, y - buttonHeight / 2 + buttonTextYOffset, buttonFont, subTextColor, buttonScale, false, shadow, true)
+            end
         end
     end
 end
-
 
 -- API
 
@@ -289,7 +313,12 @@ function WarMenu.CloseMenu()
 end
 
 
-function WarMenu.Button(text, subText)
+function WarMenu.Button(text, textureDictMain, textureNameMain, subText, textureDictSub, textureNameSub)
+    textureDictMain = textureDictMain or "commonmenu"
+    textureNameMain = textureNameMain or "shop_tick_icon"
+    textureDictSub = textureDictSub or "commonmenu"
+    textureNameSub = textureNameSub or "shop_tick_icon"
+    
     local buttonText = text
     if subText then
         buttonText = '{ '..tostring(buttonText)..', '..tostring(subText)..' }'
@@ -300,7 +329,7 @@ function WarMenu.Button(text, subText)
 
         local isCurrent = menus[currentMenu].currentOption == optionCount
 
-        drawButton(text, subText)
+        drawButton(text, textureDictMain, textureNameMain, subText, textureDictSub, textureNameSub)
 
         if isCurrent then
             if currentKey == keys.select then
@@ -338,12 +367,17 @@ end
 
 
 function WarMenu.CheckBox(text, bool, callback)
-    local checked = 'Off'
+    local checkedTexture = "shop_tick_icon"
+    local uncheckedTexture = "shop_box_blank"
+
+    local currentTexture = uncheckedTexture
+    --local checked = 'Off'
     if bool then
-        checked = 'On'
+        currentTexture = checkedTexture
+        --checked = 'On'
     end
 
-    if WarMenu.Button(text, checked) then
+    if WarMenu.Button(text, false, false, "*_SPRITE_*", "commonmenu", currentTexture) then
         bool = not bool
         debugPrint(tostring(text)..' checkbox changed to '..tostring(bool))
         callback(bool)
@@ -364,7 +398,7 @@ function WarMenu.ComboBox(text, items, currentIndex, selectedIndex, callback)
         selectedItem = '← '..tostring(selectedItem)..' →'
     end
 
-    if WarMenu.Button(text, selectedItem) then
+    if WarMenu.Button(text, false, false, selectedItem) then
         selectedIndex = currentIndex
         callback(currentIndex, selectedIndex)
         return true


### PR DESCRIPTION
Description:
- Two new arguments for buttons for each texts (main and sub texts). 
- If you want to use sprites, set the text as *_SPRITE_* and then for the next two arguments, add the texture/sprite dictionary for the first, then the name of it for the second. (They can be found here: https://pastebin.com/R5AbQJqb )
- Checkboxes have been changed to use a tick or empty box instead of On and Off. Could maybe add an option to enable/disable this so it can also show text if desired?

Usage: 
`WarMenu.Button(text, textureDictMain, textureNameMain, subText, textureDictSub, textureNameSub)`
if you want to have only the subText use a texture/sprite, then set `textureDictMain` and `textureNameMain` to `false`.

Some qwerks:
- Because of the way colouring works in warmenu and the sprites, some will show completely black when being highlighted. This could be refactored or even a table created with known sprites that behave this way and then not change the colour if they are in use.
- The positioning for the main text isn't centered/positioned properly. For sub text, it looks good with the default position of menus, but if the menu has been set to a new position, it doesn't position properly at all. I wasn't sure how to do it properly, so I thought I'd leave it up to you to take a look at and fix. You should add a development branch so we can push things like this to them so it doesn't go to the main source.

Notes:
- The codename used to identify when to use sprites can be changed if its not desired, I just came up with it. Could also be changed to a variable.
