### PR TITLE
Auto scroll when holding a directional key

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,4 +1,4 @@
-fx_version 'adamant'
+fx_version 'cerulean'
 game 'gta5'
 
 description 'FiveM Lua Menu Framework'

--- a/warmenu.lua
+++ b/warmenu.lua
@@ -59,6 +59,8 @@ for _, key in pairs({ keys.up, keys.down, keys.left, keys.right }) do
 	lastScrollTimes[key] = GetGameTimer()
 end
 
+local scrollInterval = 125
+
 local function setMenuProperty(id, property, value)
 	if not id then
 		return
@@ -533,7 +535,7 @@ function WarMenu.Display()
 			local currentTime = GetGameTimer()
 
 			if IsDisabledControlPressed(0, keys.down) then
-				if (currentTime - lastScrollTimes[keys.down]) > 125 then
+				if (currentTime - lastScrollTimes[keys.down]) > scrollInterval then
 					PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', true)
 
 					if currentMenu.currentOption < optionCount then
@@ -545,7 +547,7 @@ function WarMenu.Display()
 					lastScrollTimes[keys.down] = currentTime
 				end
 			elseif IsDisabledControlPressed(0, keys.up) then
-				if (currentTime - lastScrollTimes[keys.up]) > 125 then
+				if (currentTime - lastScrollTimes[keys.up]) > scrollInterval then
 
 					PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', true)
 
@@ -558,12 +560,12 @@ function WarMenu.Display()
 					lastScrollTimes[keys.up] = currentTime
 				end
 			elseif IsDisabledControlPressed(0, keys.left) then
-				if (currentTime - lastScrollTimes[keys.left]) > 125 then
+				if (currentTime - lastScrollTimes[keys.left]) > scrollInterval then
 					currentKey = keys.left
 					lastScrollTimes[keys.left] = currentTime
 				end
 			elseif IsDisabledControlPressed(0, keys.right) then
-				if (currentTime - lastScrollTimes[keys.right]) > 125 then
+				if (currentTime - lastScrollTimes[keys.right]) > scrollInterval then
 					currentKey = keys.right
 					lastScrollTimes[keys.right] = currentTime
 				end

--- a/warmenu.lua
+++ b/warmenu.lua
@@ -53,10 +53,10 @@ local defaultStyle = {
 	buttonPressedSound = { name = 'SELECT', set = 'HUD_FRONTEND_DEFAULT_SOUNDSET' }, --https://pastebin.com/0neZdsZ5
 }
 
-local lastScroll = {}
+local lastScrollTimes = {}
 
 for _, key in pairs({ keys.up, keys.down, keys.left, keys.right }) do
-	lastScroll[key] = GetGameTimer()
+	lastScrollTimes[key] = GetGameTimer()
 end
 
 local function setMenuProperty(id, property, value)
@@ -533,7 +533,7 @@ function WarMenu.Display()
 			local currentTime = GetGameTimer()
 
 			if IsDisabledControlPressed(0, keys.down) then
-				if (currentTime - lastScroll[keys.down]) > 125 then
+				if (currentTime - lastScrollTimes[keys.down]) > 125 then
 					PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', true)
 
 					if currentMenu.currentOption < optionCount then
@@ -542,10 +542,10 @@ function WarMenu.Display()
 						currentMenu.currentOption = 1
 					end
 
-					lastScroll[keys.down] = currentTime
+					lastScrollTimes[keys.down] = currentTime
 				end
 			elseif IsDisabledControlPressed(0, keys.up) then
-				if (currentTime - lastScroll[keys.up]) > 125 then
+				if (currentTime - lastScrollTimes[keys.up]) > 125 then
 
 					PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', true)
 
@@ -555,17 +555,17 @@ function WarMenu.Display()
 						currentMenu.currentOption = optionCount
 					end
 
-					lastScroll[keys.up] = currentTime
+					lastScrollTimes[keys.up] = currentTime
 				end
 			elseif IsDisabledControlPressed(0, keys.left) then
-				if (currentTime - lastScroll[keys.left]) > 125 then
+				if (currentTime - lastScrollTimes[keys.left]) > 125 then
 					currentKey = keys.left
-					lastScroll[keys.left] = currentTime
+					lastScrollTimes[keys.left] = currentTime
 				end
 			elseif IsDisabledControlPressed(0, keys.right) then
-				if (currentTime - lastScroll[keys.right]) > 125 then
+				if (currentTime - lastScrollTimes[keys.right]) > 125 then
 					currentKey = keys.right
-					lastScroll[keys.right] = currentTime
+					lastScrollTimes[keys.right] = currentTime
 				end
 			elseif IsControlJustReleased(0, keys.select) then
 				currentKey = keys.select

--- a/warmenu.lua
+++ b/warmenu.lua
@@ -53,6 +53,12 @@ local defaultStyle = {
 	buttonPressedSound = { name = 'SELECT', set = 'HUD_FRONTEND_DEFAULT_SOUNDSET' }, --https://pastebin.com/0neZdsZ5
 }
 
+local lastScroll = {}
+
+for _, key in pairs({ keys.up, keys.down, keys.left, keys.right }) do
+	lastScroll[key] = GetGameTimer()
+end
+
 local function setMenuProperty(id, property, value)
 	if not id then
 		return
@@ -524,27 +530,43 @@ function WarMenu.Display()
 			drawSubTitle()
 
 			currentKey = nil
+			local current_time = GetGameTimer()
 
-			if IsDisabledControlJustReleased(0, keys.down) then
-				PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', true)
+			if IsDisabledControlPressed(0, keys.down) then
+				if (current_time - lastScroll[keys.down]) > 125 then
+					PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', true)
 
-				if currentMenu.currentOption < optionCount then
-					currentMenu.currentOption = currentMenu.currentOption + 1
-				else
-					currentMenu.currentOption = 1
+					if currentMenu.currentOption < optionCount then
+						currentMenu.currentOption = currentMenu.currentOption + 1
+					else
+						currentMenu.currentOption = 1
+					end
+
+					lastScroll[keys.down] = current_time
 				end
-			elseif IsDisabledControlJustReleased(0, keys.up) then
-				PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', true)
+			elseif IsDisabledControlPressed(0, keys.up) then
+				if (current_time - lastScroll[keys.up]) > 125 then
 
-				if currentMenu.currentOption > 1 then
-					currentMenu.currentOption = currentMenu.currentOption - 1
-				else
-					currentMenu.currentOption = optionCount
+					PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', true)
+
+					if currentMenu.currentOption > 1 then
+						currentMenu.currentOption = currentMenu.currentOption - 1
+					else
+						currentMenu.currentOption = optionCount
+					end
+
+					lastScroll[keys.up] = current_time
 				end
-			elseif IsDisabledControlJustReleased(0, keys.left) then
-				currentKey = keys.left
-			elseif IsDisabledControlJustReleased(0, keys.right) then
-				currentKey = keys.right
+			elseif IsDisabledControlPressed(0, keys.left) then
+				if (current_time - lastScroll[keys.left]) > 125 then
+					currentKey = keys.left
+					lastScroll[keys.left] = current_time
+				end
+			elseif IsDisabledControlPressed(0, keys.right) then
+				if (current_time - lastScroll[keys.right]) > 125 then
+					currentKey = keys.right
+					lastScroll[keys.right] = current_time
+				end
 			elseif IsControlJustReleased(0, keys.select) then
 				currentKey = keys.select
 			elseif IsDisabledControlJustReleased(0, keys.back) then

--- a/warmenu.lua
+++ b/warmenu.lua
@@ -530,10 +530,10 @@ function WarMenu.Display()
 			drawSubTitle()
 
 			currentKey = nil
-			local current_time = GetGameTimer()
+			local currentTime = GetGameTimer()
 
 			if IsDisabledControlPressed(0, keys.down) then
-				if (current_time - lastScroll[keys.down]) > 125 then
+				if (currentTime - lastScroll[keys.down]) > 125 then
 					PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', true)
 
 					if currentMenu.currentOption < optionCount then
@@ -542,10 +542,10 @@ function WarMenu.Display()
 						currentMenu.currentOption = 1
 					end
 
-					lastScroll[keys.down] = current_time
+					lastScroll[keys.down] = currentTime
 				end
 			elseif IsDisabledControlPressed(0, keys.up) then
-				if (current_time - lastScroll[keys.up]) > 125 then
+				if (currentTime - lastScroll[keys.up]) > 125 then
 
 					PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', true)
 
@@ -555,17 +555,17 @@ function WarMenu.Display()
 						currentMenu.currentOption = optionCount
 					end
 
-					lastScroll[keys.up] = current_time
+					lastScroll[keys.up] = currentTime
 				end
 			elseif IsDisabledControlPressed(0, keys.left) then
-				if (current_time - lastScroll[keys.left]) > 125 then
+				if (currentTime - lastScroll[keys.left]) > 125 then
 					currentKey = keys.left
-					lastScroll[keys.left] = current_time
+					lastScroll[keys.left] = currentTime
 				end
 			elseif IsDisabledControlPressed(0, keys.right) then
-				if (current_time - lastScroll[keys.right]) > 125 then
+				if (currentTime - lastScroll[keys.right]) > 125 then
 					currentKey = keys.right
-					lastScroll[keys.right] = current_time
+					lastScroll[keys.right] = currentTime
 				end
 			elseif IsControlJustReleased(0, keys.select) then
 				currentKey = keys.select


### PR DESCRIPTION
This PR enables auto-scrolling when holding down a directional key (up/down for menus, left/right for combo boxes) as suggested in #6 and #11. The interval between scrolls is hard-coded to 125 ms using the GetGameTimer() native. 125 was chosen because 100 felt a bit too fast and 150 a bit too slow. This could potentially become a configurable option, but I don't see a need for that (at least for now). 

This change does not decrease performance. To confirm this, I used resmon to compare CPU time when scrolling as fast as possible on master against the CPU time when using auto_scroll and there was no increase in CPU time. 
