### PR TITLE
fix: windowTitleEntry not displaying

### DIFF
--- a/warmenu.lua
+++ b/warmenu.lua
@@ -411,7 +411,12 @@ function WarMenu.InputButton(text, windowTitleEntry, defaultText, maxLength, sub
 	local inputText = nil
 
 	if pressed then
-		DisplayOnscreenKeyboard(1, windowTitleEntry or 'FMMC_MPM_NA', '', defaultText or '', '', '', '', maxLength or 255)
+		if windowTitleEntry == nil then
+			windowTitleEntry = ''
+		end
+
+		AddTextEntry('FMMC_MPM_NA', windowTitleEntry)
+		DisplayOnscreenKeyboard(1, 'FMMC_MPM_NA', '', defaultText or '', '', '', '', maxLength or 255)
 
 		while true do
 			DisableAllControlActions(0)


### PR DESCRIPTION
Before if you entered a custom windowTitleEntry for WarMenu.InputButton, the title would be blank rather than the custom entry. That is fixed in this commit.

Before: https://i.imgur.com/kBm2POR.png

After: https://i.imgur.com/1K3A6ih.png